### PR TITLE
fix: export types in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "types": "dist/index.d.ts",
   "exports": {
     "require": "./dist/index.js",
-    "default": "./dist/index-esm.mjs"
+    "default": "./dist/index-esm.mjs",
+    "types": "./dist/index.d.ts"
   },
   "engines": {
     "node": "^12.22 || ^14.13 || >=16"


### PR DESCRIPTION
The module doesn't work with modern Typescript/ESM setup due to:

> Could not find a declaration file for module 'uuid-basex'. '/Users/is/work/b/node_modules/.pnpm/uuid-basex@2.0.3/node_modules/uuid-basex/dist/index-esm.mjs' implicitly has an 'any' type.
>  There are types at '/Users/is/work/b/node_modules/uuid-basex/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'uuid-basex' library may need to update its package.json or typings.

The PR fixes that.